### PR TITLE
Make NavBar's primary button scale transition work

### DIFF
--- a/landing-blocks/src/NavBar.tsx
+++ b/landing-blocks/src/NavBar.tsx
@@ -28,7 +28,6 @@ export const NavBar = ({ logo, navs = [], ...rest }: NavBarProps) => {
                 <Box flex='1' />
                 <Stack
                     maxW='100%'
-                    isTruncated
                     direction='row'
                     spacing='20px'
                     align='center'


### PR DESCRIPTION
This change makes the navbar Primary Button transform scale work as they should.

**From**

![image](https://user-images.githubusercontent.com/39694575/84980471-d27a8900-b14f-11ea-960c-e81b88c68e94.png)

**To**

![image](https://user-images.githubusercontent.com/39694575/84980506-e625ef80-b14f-11ea-8bb7-2e6e5cc4c4e1.png)

Also this fixes the navbar in - https://dokz.site/

**Note:** I am not aware why you have included `istrucated`.

Kindly review and remove it, to make the navbar great again.


